### PR TITLE
Add registration warning popup to websocket-only users without GCM

### DIFF
--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -345,11 +345,14 @@
         than 4.0 must have a registered Google Account. Devices running Android 4.0 or newer do not
         require a Google account, but must have the Play Store app installed.
     </string>
+    <string name="RegistrationActivity_websockets_only_unsupported">"This device setup is not officially supported, and if you experience bugs you will have to resolve them yourself."
+    </string>
     <string name="RegistrationActivity_we_will_now_verify_that_the_following_number_is_associated_with_your_device_s">
         Double-check that this is your number! We\'re about to verify it with an SMS.
     </string>
     <string name="RegistrationActivity_continue">Continue</string>
     <string name="RegistrationActivity_edit">Edit</string>
+    <string name="RegistrationActivity_I_understand">I Understand</string>
 
     <!-- RegistrationProblemsActivity -->
     <string name="RegistrationProblemsActivity_possible_problems">Possible problems</string>

--- a/src/org/thoughtcrime/securesms/RegistrationActivity.java
+++ b/src/org/thoughtcrime/securesms/RegistrationActivity.java
@@ -199,7 +199,7 @@ public class RegistrationActivity extends BaseActionBarActivity {
       int gcmStatus = GooglePlayServicesUtil.isGooglePlayServicesAvailable(self);
 
       if (gcmStatus != ConnectionResult.SUCCESS) {
-        if(gcmStatus == ConnectionResult.SERVICE_MISSING && BuildConfig.FORCE_WEBSOCKETS) {
+        if(BuildConfig.FORCE_WEBSOCKETS) {
           AlertDialogWrapper.Builder unsupportedDialog = new AlertDialogWrapper.Builder(self);
           unsupportedDialog.setTitle(getString(R.string.RegistrationActivity_unsupported));
           unsupportedDialog.setMessage(getString(R.string.RegistrationActivity_websockets_only_unsupported));

--- a/src/org/thoughtcrime/securesms/RegistrationActivity.java
+++ b/src/org/thoughtcrime/securesms/RegistrationActivity.java
@@ -26,6 +26,7 @@ import com.google.i18n.phonenumbers.NumberParseException;
 import com.google.i18n.phonenumbers.PhoneNumberUtil;
 import com.google.i18n.phonenumbers.Phonenumber;
 
+import org.thoughtcrime.securesms.BuildConfig;
 import org.thoughtcrime.securesms.crypto.MasterSecret;
 import org.thoughtcrime.securesms.util.Dialogs;
 import org.thoughtcrime.securesms.util.TextSecurePreferences;
@@ -198,31 +199,49 @@ public class RegistrationActivity extends BaseActionBarActivity {
       int gcmStatus = GooglePlayServicesUtil.isGooglePlayServicesAvailable(self);
 
       if (gcmStatus != ConnectionResult.SUCCESS) {
-        if (GooglePlayServicesUtil.isUserRecoverableError(gcmStatus)) {
+        if(gcmStatus == ConnectionResult.SERVICE_MISSING && BuildConfig.FORCE_WEBSOCKETS) {
+          AlertDialogWrapper.Builder unsupportedDialog = new AlertDialogWrapper.Builder(self);
+          unsupportedDialog.setTitle(getString(R.string.RegistrationActivity_unsupported));
+          unsupportedDialog.setMessage(getString(R.string.RegistrationActivity_websockets_only_unsupported));
+          unsupportedDialog.setPositiveButton(getString(R.string.RegistrationActivity_I_understand),
+                                              new DialogInterface.OnClickListener() {
+                                                @Override
+                                                public void onClick(DialogInterface dialog, int which) {
+                                                  showDoubleCheckDialog(self,e164number);
+                                                }
+                                              });
+          unsupportedDialog.show();
+        } else if (GooglePlayServicesUtil.isUserRecoverableError(gcmStatus)) {
           GooglePlayServicesUtil.getErrorDialog(gcmStatus, self, 9000).show();
+          return;
         } else {
           Dialogs.showAlertDialog(self, getString(R.string.RegistrationActivity_unsupported),
                                   getString(R.string.RegistrationActivity_sorry_this_device_is_not_supported_for_data_messaging));
+          return;
         }
+      } else {
+        showDoubleCheckDialog(self,e164number);
       }
-
-      AlertDialogWrapper.Builder dialog = new AlertDialogWrapper.Builder(self);
-      dialog.setTitle(PhoneNumberFormatter.getInternationalFormatFromE164(e164number));
-      dialog.setMessage(R.string.RegistrationActivity_we_will_now_verify_that_the_following_number_is_associated_with_your_device_s);
-      dialog.setPositiveButton(getString(R.string.RegistrationActivity_continue),
-                               new DialogInterface.OnClickListener() {
-                                 @Override
-                                 public void onClick(DialogInterface dialog, int which) {
-                                   Intent intent = new Intent(self, RegistrationProgressActivity.class);
-                                   intent.putExtra("e164number", e164number);
-                                   intent.putExtra("master_secret", masterSecret);
-                                   startActivity(intent);
-                                   finish();
-                                 }
-                               });
-      dialog.setNegativeButton(getString(R.string.RegistrationActivity_edit), null);
-      dialog.show();
     }
+  }
+
+  private void showDoubleCheckDialog(final RegistrationActivity self, final String e164number){
+    AlertDialogWrapper.Builder dialog = new AlertDialogWrapper.Builder(self);
+    dialog.setTitle(PhoneNumberFormatter.getInternationalFormatFromE164(e164number));
+    dialog.setMessage(R.string.RegistrationActivity_we_will_now_verify_that_the_following_number_is_associated_with_your_device_s);
+    dialog.setPositiveButton(getString(R.string.RegistrationActivity_continue),
+                             new DialogInterface.OnClickListener() {
+                               @Override
+                               public void onClick(DialogInterface dialog, int which) {
+                                 Intent intent = new Intent(self, RegistrationProgressActivity.class);
+                                 intent.putExtra("e164number", e164number);
+                                 intent.putExtra("master_secret", masterSecret);
+                                 startActivity(intent);
+                                 finish();
+                               }
+                             });
+    dialog.setNegativeButton(getString(R.string.RegistrationActivity_edit), null);
+    dialog.show();
   }
 
   private class CountryCodeChangedListener implements TextWatcher {


### PR DESCRIPTION
So if you look at the old way RegistrationActivity.java does this there's a race condition in the UI between the "No google play warning" and the "are you sure this is your phone number?" warning. Additionally I think its important to warn users of the websocket branch that its possible the code will be very buggy and unstable.
![screen](https://cloud.githubusercontent.com/assets/4326714/8886026/8b0f5374-322a-11e5-9a98-2490cc08bfb3.png)
