### PR TITLE
Make FORCE_WEBSOCKETS option configurable at runtime (not build-time)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -174,7 +174,6 @@ android {
         buildConfigField "String", "REDPHONE_RELAY_HOST", "\"relay.whispersystems.org\""
         buildConfigField "String", "REDPHONE_PREFIX_NAME", "\".whispersystems.org\""
         buildConfigField "boolean", "DEV_BUILD", "false"
-        buildConfigField "boolean", "FORCE_WEBSOCKETS", "false"
     }
 
     compileOptions {
@@ -223,10 +222,6 @@ android {
             buildConfigField "boolean", "DEV_BUILD", "true"
             applicationIdSuffix ".dev"
             versionNameSuffix "-dev"
-        }
-        websockets.initWith(buildTypes.dev)
-        websockets {
-            buildConfigField "boolean", "FORCE_WEBSOCKETS", "true"
         }
     }
 

--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -840,6 +840,8 @@
     <string name="preferences__input_settings">Input Settings</string>
     <string name="preferences__enable_enter_key_title">Enable Enter key</string>
     <string name="preferences__replace_smiley_with_enter_key">Replace the smiley key with an Enter key</string>
+    <string name="preferences__pref_force_websocket_title">Force WebSocket</string>
+    <string name="preferences__always_use_websocket_instead_of_gcm">Always use WebSocket instead of GCM</string>
     <string name="preferences__pref_enter_sends_title">Enter key sends</string>
     <string name="preferences__pressing_the_enter_key_will_send_text_messages">Pressing the Enter key will send text messages</string>
     <string name="preferences__display_settings">Display settings</string>

--- a/res/xml/preferences_advanced.xml
+++ b/res/xml/preferences_advanced.xml
@@ -9,6 +9,12 @@
 
     <org.thoughtcrime.securesms.components.SwitchPreferenceCompat
                         android:defaultValue="false"
+                        android:key="pref_force_websocket"
+                        android:summary="@string/preferences__always_use_websocket_instead_of_gcm"
+                        android:title="@string/preferences__pref_force_websocket_title"/>
+
+    <org.thoughtcrime.securesms.components.SwitchPreferenceCompat
+                        android:defaultValue="false"
                         android:key="pref_enter_sends"
                         android:summary="@string/preferences__pressing_the_enter_key_will_send_text_messages"
                         android:title="@string/preferences__pref_enter_sends_title"/>

--- a/src/org/thoughtcrime/securesms/jobs/GcmRefreshJob.java
+++ b/src/org/thoughtcrime/securesms/jobs/GcmRefreshJob.java
@@ -67,7 +67,7 @@ public class GcmRefreshJob extends ContextJob implements InjectableType {
       Log.w(TAG, "GCM registrationId expired, reregistering...");
       int result = GooglePlayServicesUtil.isGooglePlayServicesAvailable(context);
 
-      if (result != ConnectionResult.SUCCESS || BuildConfig.FORCE_WEBSOCKETS) {
+      if (result != ConnectionResult.SUCCESS || TextSecurePreferences.isForceWebsocketEnabled(context)) {
         notifyGcmFailure();
       } else {
         String gcmId = GoogleCloudMessaging.getInstance(context).register(REGISTRATION_ID);

--- a/src/org/thoughtcrime/securesms/service/RegistrationService.java
+++ b/src/org/thoughtcrime/securesms/service/RegistrationService.java
@@ -245,7 +245,7 @@ public class RegistrationService extends Service {
     accountManager.setPreKeys(identityKey.getPublicKey(),lastResort, signedPreKey, records);
 
     if (GooglePlayServicesUtil.isGooglePlayServicesAvailable(this) == ConnectionResult.SUCCESS &&
-        !BuildConfig.FORCE_WEBSOCKETS)
+        !TextSecurePreferences.isForceWebsocketEnabled(this))
     {
       setState(new RegistrationState(RegistrationState.STATE_GCM_REGISTERING, number));
 
@@ -260,17 +260,16 @@ public class RegistrationService extends Service {
     DatabaseFactory.getIdentityDatabase(this).saveIdentity(self.getRecipientId(), identityKey.getPublicKey());
     DirectoryHelper.refreshDirectory(this, accountManager, number);
 
-    //if (GooglePlayServicesUtil.isGooglePlayServicesAvailable(this) == ConnectionResult.SUCCESS &&
-    //    !BuildConfig.FORCE_WEBSOCKETS)
-    //{
-    //  RedPhoneAccountManager redPhoneAccountManager = new RedPhoneAccountManager(BuildConfig.REDPHONE_MASTER_URL,
-    //                                                                           new RedPhoneTrustStore(this),
-    //                                                                           number, password);
-    //  String verificationToken = accountManager.getAccountVerificationToken();
-    //  redPhoneAccountManager.createAccount(verificationToken, new RedPhoneAccountAttributes(signalingKey,
-    //          TextSecurePreferences.getGcmRegistrationId(this)));
-    //}
-    accountManager.getAccountVerificationToken();
+    String verificationToken = accountManager.getAccountVerificationToken();
+    if (GooglePlayServicesUtil.isGooglePlayServicesAvailable(this) == ConnectionResult.SUCCESS &&
+        !TextSecurePreferences.isForceWebsocketEnabled(this))
+    {
+      RedPhoneAccountManager redPhoneAccountManager = new RedPhoneAccountManager(BuildConfig.REDPHONE_MASTER_URL,
+                                                                                 new RedPhoneTrustStore(this),
+                                                                                 number, password);
+      redPhoneAccountManager.createAccount(verificationToken, new RedPhoneAccountAttributes(signalingKey,
+              TextSecurePreferences.getGcmRegistrationId(this)));
+    }
 
     DirectoryRefreshListener.schedule(this);
   }

--- a/src/org/thoughtcrime/securesms/util/TextSecurePreferences.java
+++ b/src/org/thoughtcrime/securesms/util/TextSecurePreferences.java
@@ -56,6 +56,7 @@ public class TextSecurePreferences {
   public  static final String PASSPHRASE_TIMEOUT_INTERVAL_PREF = "pref_timeout_interval";
   private static final String PASSPHRASE_TIMEOUT_PREF          = "pref_timeout_passphrase";
   public  static final String SCREEN_SECURITY_PREF             = "pref_screen_security";
+  private static final String FORCE_WEBSOCKET_PREF             = "pref_force_websocket";
   private static final String ENTER_SENDS_PREF                 = "pref_enter_sends";
   private static final String ENTER_PRESENT_PREF               = "pref_enter_key";
   private static final String SMS_DELIVERY_REPORT_PREF         = "pref_delivery_report_sms";
@@ -210,6 +211,10 @@ public class TextSecurePreferences {
 
   public static String getSignalingKey(Context context) {
     return getStringPreference(context, SIGNALING_KEY_PREF, null);
+  }
+
+  public static boolean isForceWebsocketEnabled(Context context) {
+    return getBooleanPreference(context, FORCE_WEBSOCKET_PREF, false);
   }
 
   public static boolean isEnterImeKeyEnabled(Context context) {

--- a/test/androidTestEspresso/java/org/thoughtcrime/securesms/preferences/AdvancedPreferenceFragmentActions.java
+++ b/test/androidTestEspresso/java/org/thoughtcrime/securesms/preferences/AdvancedPreferenceFragmentActions.java
@@ -28,6 +28,10 @@ public class AdvancedPreferenceFragmentActions {
     onData(Matchers.<Object>allOf(withKey("pref_toggle_push_messaging"))).perform(click());
   }
 
+  public static void clickForceWebsocket() throws Exception {
+    onData(Matchers.<Object>allOf(withKey("pref_force_websocket"))).perform(click());
+  }
+
   public static void clickEnterKeySends() throws Exception {
     onData(Matchers.<Object>allOf(withKey("pref_enter_sends"))).perform(click());
   }

--- a/test/androidTestEspresso/java/org/thoughtcrime/securesms/preferences/AdvancedPreferenceFragmentTest.java
+++ b/test/androidTestEspresso/java/org/thoughtcrime/securesms/preferences/AdvancedPreferenceFragmentTest.java
@@ -51,6 +51,8 @@ public class AdvancedPreferenceFragmentTest extends TextSecureEspressoTestCase<C
   private void checkAllPreferencesDisplayed() throws Exception {
     onData(Matchers.<Object>allOf(withKey("pref_toggle_push_messaging")))
           .check(matches(isDisplayed()));
+    onData(Matchers.<Object>allOf(withKey("pref_force_websocket")))
+          .check(matches(isDisplayed()));
     onData(Matchers.<Object>allOf(withKey("pref_enter_sends")))
           .check(matches(isDisplayed()));
     onData(Matchers.<Object>allOf(withKey("pref_submit_debug_logs")))
@@ -68,6 +70,12 @@ public class AdvancedPreferenceFragmentTest extends TextSecureEspressoTestCase<C
       isChecked().matches(onData(Matchers.<Object>allOf(withKey("pref_toggle_push_messaging"))));
     } else {
       isNotChecked().matches(onData(Matchers.<Object>allOf(withKey("pref_toggle_push_messaging"))));
+    }
+
+    if (TextSecurePreferences.isForceWebsocketEnabled(getContext())) {
+      isChecked().matches(onData(Matchers.<Object>allOf(withKey("pref_force_websocket"))));
+    } else {
+      isNotChecked().matches(onData(Matchers.<Object>allOf(withKey("pref_force_websocket"))));
     }
 
     if (TextSecurePreferences.isEnterSendsEnabled(getContext())) {


### PR DESCRIPTION
This is simple change that will make it possible to use WebSocket instead of GCM even on devices which _have_ Google Play Services installed. Now it is needed to maintain two builds (one with FORCE_WEBSOCKETS build-time option enabled and one without it) for this purposes, this would make only one universal build sufficient.

You will find the _Force WebSocket_ option in Advanced Settings.
